### PR TITLE
Require updated docker-run

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "brfs": "^1.2.0",
     "computed-style": "^0.1.3",
     "defaultcss": "0.0.2",
-    "docker-run": "^2.0.0",
+    "docker-run": "^3.0.0",
     "duplexify": "^3.2.0",
     "ndjson": "^1.2.3",
     "term.js": "^0.0.4",


### PR DESCRIPTION
More recent docker-run is required to fix "starting container with non-empty request body was deprecated since v1.10 and removed in v1.12"